### PR TITLE
chore: remove `zeebe:PropertiesHolder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.18.0
+
+* `CHORE`: remove `zeebe:PropertiesHolder` type ([#44](https://github.com/camunda/zeebe-bpmn-moddle/pull/44))
+
+### Breaking Changes
+
+* `zeebe:PropertiesHolder` type removed without replacement as `zeebe:Properties` extension elements are generally allowed
+
 ## 0.17.0
 
 * `FEAT`: support `zeebe:script` ([#39](https://github.com/camunda/zeebe-bpmn-moddle/pull/39))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -346,12 +346,7 @@
           "type": "Property",
           "isMany": true
         }
-      ],
-      "meta": {
-        "allowedIn": [
-          "zeebe:PropertiesHolder"
-        ]
-      }
+      ]
     },
     {
       "name": "Property",
@@ -366,18 +361,6 @@
           "type": "String",
           "isAttr": true
         }
-      ],
-      "meta": {
-        "allowedIn": [
-          "zeebe:PropertiesHolder"
-        ]
-      }
-    },
-    {
-      "name": "PropertiesHolder",
-      "isAbstract": true,
-      "extends": [
-        "bpmn:FlowNode"
       ]
     },
     {


### PR DESCRIPTION
Will be followed up by a pull request in `bpmn-js-properties-panel` that removes the check for `zeebe:PropertiesHolder`.

---

Closes #43