### PR TITLE
feat: add `zeebe:TaskSchedule` extension element

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -336,6 +336,29 @@
       ]
     },
     {
+      "name": "TaskSchedule",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:UserTask"
+        ]
+      },
+      "properties": [
+        {
+          "name": "dueDate",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "followUpDate",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
+    },
+    {
       "name": "Properties",
       "superClass": [
         "Element"

--- a/test/fixtures/xml/userTask-zeebe-taskSchedule.part.bpmn
+++ b/test/fixtures/xml/userTask-zeebe-taskSchedule.part.bpmn
@@ -1,0 +1,11 @@
+<bpmn:userTask
+  id="user-task-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:taskSchedule
+      dueDate="2023-04-20T04:20:00Z"
+      followUpDate="=followUpDate" />
+  </bpmn:extensionElements>
+</bpmn:userTask>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -527,7 +527,7 @@ describe('read', function() {
     });
 
 
-    describe('zeebe:assignmentDefinition', function() {
+    describe('zeebe:AssignmentDefinition', function() {
 
       it('on UserTask', async function() {
 
@@ -551,6 +551,38 @@ describe('read', function() {
                 assignee: '= ring.bearer',
                 candidateGroups: 'elves, men, dwarfs, hobbits',
                 candidateUsers: 'saruman, gandalf'
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
+
+    describe('zeebe:TaskSchedule', function() {
+
+      it('on UserTask', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/userTask-zeebe-taskSchedule.part.bpmn');
+
+        // when
+        const {
+          rootElement: task
+        } = await moddle.fromXML(xml, 'bpmn:UserTask');
+
+        // then
+        expect(task).to.jsonEqual({
+          $type: 'bpmn:UserTask',
+          id: 'user-task-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:TaskSchedule',
+                dueDate: '2023-04-20T04:20:00Z',
+                followUpDate: '=followUpDate'
               }
             ]
           }

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -206,7 +206,7 @@ describe('write', function() {
     });
 
 
-    it('zeebe:assignmentDefinition', async function() {
+    it('zeebe:AssignmentDefinition', async function() {
 
       // given
       var assignmentDefinition = moddle.create('zeebe:AssignmentDefinition', {
@@ -223,6 +223,27 @@ describe('write', function() {
 
       // when
       const xml = await write(assignmentDefinition);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
+
+    it('zeebe:TaskSchedule', async function() {
+
+      // given
+      var taskSchedule = moddle.create('zeebe:TaskSchedule', {
+        dueDate: '2023-04-20T04:20:00Z',
+        followUpDate: '=followUpDate'
+      });
+
+      var expectedXML = '<zeebe:taskSchedule ' +
+        'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+        'dueDate="2023-04-20T04:20:00Z" ' +
+        'followUpDate="=followUpDate" />';
+
+      // when
+      const xml = await write(taskSchedule);
 
       // then
       expect(xml).to.eql(expectedXML);


### PR DESCRIPTION
Adds support for `zeebe:TaskSchedule` extension elements supported by Camunda 8.2.

```xml
<userTask id="UserTask_1">
    <extensionElements>
        <zeebe:taskSchedule dueDate="2023-04-20T04:20:00Z" followUpDate="=followUpDate" />
    </extensionElements>
</userTask>
```

---

Related to https://github.com/camunda/camunda-modeler/issues/3484