### PR TITLE
feat: support templated root elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.19.0
+
+* `FEAT`: add `zeebe:modelerTemplate` for root elements
+
 ## 0.18.0
 
 * `FEAT`: add `zeebe:TaskSchedule` extension element ([#45](https://github.com/camunda/zeebe-bpmn-moddle/pull/45))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -413,6 +413,23 @@
       ]
     },
     {
+      "name": "TemplatedRootElement",
+      "isAbstract": true,
+      "extends": [
+        "bpmn:Error",
+        "bpmn:Escalation",
+        "bpmn:Message",
+        "bpmn:Signal"
+      ],
+      "properties": [
+        {
+          "name": "modelerTemplate",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "Script",
       "superClass": [
         "Element"

--- a/test/fixtures/xml/rootElement.bpmn
+++ b/test/fixtures/xml/rootElement.bpmn
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+          xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+          targetNamespace="http://bpmn.io/schema/bpmn">
+  <message zeebe:modelerTemplate="templateId"/>
+  <error zeebe:modelerTemplate="templateId"/>
+  <signal zeebe:modelerTemplate="templateId"/>
+  <escalation zeebe:modelerTemplate="templateId"/>
+</definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -665,6 +665,49 @@ describe('read', function() {
     });
 
 
+    describe('zeebe:TemplatedRootElement', function() {
+
+      describe('zeebe:modelerTemplate', function() {
+
+        it('on root elements', async function() {
+
+          // given
+          var xml = readFile('test/fixtures/xml/rootElement.bpmn');
+
+          // when
+          const {
+            rootElement: definitions
+          } = await moddle.fromXML(xml, 'bpmn:Definitions');
+
+          // then
+          expect(definitions).to.jsonEqual({
+            $type: 'bpmn:Definitions',
+            targetNamespace: 'http://bpmn.io/schema/bpmn',
+            rootElements: [
+              {
+                $type: 'bpmn:Message',
+                modelerTemplate: 'templateId'
+              },
+              {
+                $type: 'bpmn:Error',
+                modelerTemplate: 'templateId'
+              },
+              {
+                $type: 'bpmn:Signal',
+                modelerTemplate: 'templateId'
+              },
+              {
+                $type: 'bpmn:Escalation',
+                modelerTemplate: 'templateId'
+              }
+            ]
+          });
+        });
+
+      });
+    });
+
+
     describe('zeebe:script', function() {
 
       it('on ScriptTask', async function() {

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -52,4 +52,6 @@ describe('import -> export roundtrip', function() {
 
   it('should keep zeebe:properties', validateExport('test/fixtures/xml/zeebe-properties.bpmn'));
 
+
+  it('should keep zeebe:modelerTemplate', validateExport('test/fixtures/xml/rootElement.bpmn'));
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -269,6 +269,26 @@ describe('write', function() {
     });
 
 
+    it('zeebe:modelerTemplate on root element', async function() {
+
+      // given
+      const moddleElement = moddle.create('bpmn:Message', {
+        modelerTemplate: 'foo'
+      });
+
+      const expectedXML = '<bpmn:message ' +
+      'xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+      'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+      'zeebe:modelerTemplate="foo" />';
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
+
     it('zeebe:modelerTemplateVersion', async function() {
 
       // given


### PR DESCRIPTION
```xml
<?xml version="1.0" encoding="UTF-8"?>
<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
          xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
          targetNamespace="http://bpmn.io/schema/bpmn">
  <message zeebe:modelerTemplate="templateId"/>
  <error zeebe:modelerTemplate="templateId"/>
  <signal zeebe:modelerTemplate="templateId"/>
  <escalation zeebe:modelerTemplate="templateId"/>
</definitions>
```

Related to https://github.com/camunda/camunda-modeler/issues/3403