### PR TITLE
feat: support zeebe:ExecutionListener

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -479,6 +479,58 @@
           "isAttr": true
         }
       ]
+    },
+    {
+      "name": "ExecutionListeners",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:Event",
+          "bpmn:Activity",
+          "bpmn:Process",
+          "bpmn:ExclusiveGateway",
+          "bpmn:InclusiveGateway",
+          "bpmn:ParallelGateway",
+          "bpmn:EventBasedGateway"
+        ]
+      },
+      "properties": [
+        {
+          "name": "listeners",
+          "type": "ExecutionListener",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "ExecutionListener",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "zeebe:ExecutionListeners"
+        ]
+      },
+      "properties": [
+        {
+          "name": "eventType",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "retries",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "type",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/xml/event-zeebe-executionListener.part.bpmn
+++ b/test/fixtures/xml/event-zeebe-executionListener.part.bpmn
@@ -1,0 +1,11 @@
+<bpmn:endEvent
+  id="endEvent-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:executionListeners>
+      <zeebe:executionListener eventType="start" retries="3" type="sysout"/>
+    </zeebe:executionListeners>
+  </bpmn:extensionElements>
+</bpmn:endEvent>

--- a/test/fixtures/xml/gateway-zeebe-executionListener.part.bpmn
+++ b/test/fixtures/xml/gateway-zeebe-executionListener.part.bpmn
@@ -1,0 +1,11 @@
+<bpmn:exclusiveGateway
+  id="exclusiveGateway-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:executionListeners>
+      <zeebe:executionListener eventType="start" retries="3" type="sysout"/>
+    </zeebe:executionListeners>
+  </bpmn:extensionElements>
+</bpmn:exclusiveGateway>

--- a/test/fixtures/xml/task-zeebe-executionListener.part.bpmn
+++ b/test/fixtures/xml/task-zeebe-executionListener.part.bpmn
@@ -1,0 +1,11 @@
+<bpmn:task
+  id="task-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:executionListeners>
+      <zeebe:executionListener eventType="start" retries="3" type="sysout"/>
+    </zeebe:executionListeners>
+  </bpmn:extensionElements>
+</bpmn:task>

--- a/test/fixtures/xml/zeebe-execution-listeners.bpmn
+++ b/test/fixtures/xml/zeebe-execution-listeners.bpmn
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qh9wc7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="ZeebePropertiesTest" name="Zeebe Properties Test" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_17qas0b">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="Event_0eh64r2">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_1mgtnh6">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_0j5ev99">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_0ls77qd">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:subProcess id="Activity_1yf35jc">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:startEvent id="Event_06ifkc6">
+        <bpmn:extensionElements>
+          <zeebe:executionListeners>
+            <zeebe:executionListener eventType="end" retries="3" type="sysout" />
+          </zeebe:executionListeners>
+        </bpmn:extensionElements>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebePropertiesTest">
+      <bpmndi:BPMNShape id="Event_17qas0b_di" bpmnElement="Event_17qas0b">
+        <dc:Bounds x="192" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0eh64r2_di" bpmnElement="Event_0eh64r2">
+        <dc:Bounds x="192" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mgtnh6_di" bpmnElement="Event_1mgtnh6">
+        <dc:Bounds x="192" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0j5ev99_di" bpmnElement="Gateway_0j5ev99" isMarkerVisible="true">
+        <dc:Bounds x="185" y="315" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ls77qd_di" bpmnElement="Activity_0ls77qd">
+        <dc:Bounds x="160" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1yf35jc_di" bpmnElement="Activity_1yf35jc" isExpanded="true">
+        <dc:Bounds x="160" y="510" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06ifkc6_di" bpmnElement="Event_06ifkc6">
+        <dc:Bounds x="200" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -886,6 +886,111 @@ describe('read', function() {
 
     });
 
+
+    describe('zeebe:ExecutionListener', function() {
+
+
+      it('on Task', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/task-zeebe-executionListener.part.bpmn');
+
+        // when
+        const {
+          rootElement: task
+        } = await moddle.fromXML(xml, 'bpmn:Task');
+
+        // then
+        expect(task).to.jsonEqual({
+          $type: 'bpmn:Task',
+          id: 'task-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:ExecutionListeners',
+                listeners: [
+                  {
+                    $type: 'zeebe:ExecutionListener',
+                    eventType: 'start',
+                    retries: '3',
+                    type: 'sysout'
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      });
+
+
+      it('on Event', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/event-zeebe-executionListener.part.bpmn');
+
+        // when
+        const {
+          rootElement: event
+        } = await moddle.fromXML(xml, 'bpmn:EndEvent');
+
+        // then
+        expect(event).to.jsonEqual({
+          $type: 'bpmn:EndEvent',
+          id: 'endEvent-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:ExecutionListeners',
+                listeners: [
+                  {
+                    $type: 'zeebe:ExecutionListener',
+                    eventType: 'start',
+                    retries: '3',
+                    type: 'sysout'
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      });
+
+
+      it('on Gateway', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/gateway-zeebe-executionListener.part.bpmn');
+
+        // when
+        const {
+          rootElement: gateway
+        } = await moddle.fromXML(xml, 'bpmn:ExclusiveGateway');
+
+        // then
+        expect(gateway).to.jsonEqual({
+          $type: 'bpmn:ExclusiveGateway',
+          id: 'exclusiveGateway-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:ExecutionListeners',
+                listeners: [
+                  {
+                    $type: 'zeebe:ExecutionListener',
+                    eventType: 'start',
+                    retries: '3',
+                    type: 'sysout'
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      });
+    });
   });
 
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -60,4 +60,10 @@ describe('import -> export roundtrip', function() {
 
     it('should keep zeebe:formDefinition properties', validateExport('test/fixtures/xml/userTask-zeebe-formDefinition.bpmn'));
   });
+
+
+  describe('executionListeners', function() {
+
+    it('should keep zeebe:executionListeners', validateExport('test/fixtures/xml/zeebe-execution-listeners.bpmn'));
+  });
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -489,6 +489,32 @@ describe('write', function() {
       expect(xml).to.eql(expectedXML);
     });
 
+
+    it('zeebe:ExecutionListeners', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:ExecutionListeners', {
+        listeners: [
+          moddle.create('zeebe:ExecutionListener', {
+            eventType: 'start',
+            retries: '3',
+            type: 'sysout'
+          })
+        ]
+      });
+
+      const expectedXML = '<zeebe:executionListeners ' +
+        'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">' +
+        '<zeebe:executionListener eventType="start" retries="3" type="sysout" />' +
+        '</zeebe:executionListeners>';
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });


### PR DESCRIPTION
This adds support for `zeebe:ExecutionListener` contained in `zeebe:ExecutionListeners` container. The `allowedIn` property reflects the table from https://github.com/camunda/camunda-docs/pull/4017

Related to https://github.com/camunda/camunda-modeler/issues/3951