### PR TITLE
feat: support `zeebe:VersionTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.3.0
+
+* `FEAT`: support `zeebe:VersionTag` ([#60](https://github.com/camunda/zeebe-bpmn-moddle/pull/60))
+
 ## 1.2.0
 
 * `FEAT`: support: `zeebe:ExecutionListener` ([#57](https://github.com/camunda/zeebe-bpmn-moddle/pull/57))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -531,6 +531,24 @@
           "isAttr": true
         }
       ]
+    },
+    {
+      "name": "VersionTag",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:Process"
+        ]
+      },
+      "properties": [
+        {
+          "name": "value",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/xml/zeebe-versionTag.bpmn
+++ b/test/fixtures/xml/zeebe-versionTag.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="v1.0.0" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/test/fixtures/xml/zeebe-versionTag.part.bpmn
+++ b/test/fixtures/xml/zeebe-versionTag.part.bpmn
@@ -1,0 +1,9 @@
+<bpmn:process 
+  id="process-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:versionTag value="v1.0.0" />
+  </bpmn:extensionElements>
+</bpmn:process>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -889,7 +889,6 @@ describe('read', function() {
 
     describe('zeebe:ExecutionListener', function() {
 
-
       it('on Task', async function() {
 
         // given
@@ -990,7 +989,40 @@ describe('read', function() {
           }
         });
       });
+
     });
+
+
+    describe('zeebe:VersionTag', function() {
+
+      it('on Process', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/zeebe-versionTag.part.bpmn');
+
+        // when
+        const {
+          rootElement: task
+        } = await moddle.fromXML(xml, 'bpmn:Process');
+
+        // then
+        expect(task).to.jsonEqual({
+          $type: 'bpmn:Process',
+          id: 'process-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:VersionTag',
+                value: 'v1.0.0'
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -4,7 +4,6 @@ var readFile = require('../../helper').readFile,
     createModdle = require('../../helper').createModdle;
 
 
-
 describe('import -> export roundtrip', function() {
 
   function stripSpaces(xml) {
@@ -43,9 +42,9 @@ describe('import -> export roundtrip', function() {
   }
 
 
-  describe('should keep zeebe attributes', function() {
+  describe('Zeebe properties', function() {
 
-    it('Service Task:FormData', validateExport('test/fixtures/xml/simple.bpmn'));
+    it('should keep Zeebe properties', validateExport('test/fixtures/xml/simple.bpmn'));
 
   });
 
@@ -56,14 +55,24 @@ describe('import -> export roundtrip', function() {
   it('should keep zeebe:modelerTemplate', validateExport('test/fixtures/xml/rootElement.bpmn'));
 
 
-  describe('userTask', function() {
+  describe('zeebe:UserTask', function() {
 
     it('should keep zeebe:formDefinition properties', validateExport('test/fixtures/xml/userTask-zeebe-formDefinition.bpmn'));
+
   });
 
 
-  describe('executionListeners', function() {
+  describe('zeebe:ExecutionListeners', function() {
 
     it('should keep zeebe:executionListeners', validateExport('test/fixtures/xml/zeebe-execution-listeners.bpmn'));
+
   });
+
+
+  describe('zeebe:VersionTag', function() {
+
+    it('should keep zeebe:versionTag', validateExport('test/fixtures/xml/zeebe-versionTag.bpmn'));
+
+  });
+
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -515,6 +515,25 @@ describe('write', function() {
       expect(xml).to.eql(expectedXML);
     });
 
+
+    it('zeebe:VersionTag', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:VersionTag', {
+        value: 'v1.0.0'
+      });
+
+      const expectedXML = '<zeebe:versionTag ' +
+        'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+        'value="v1.0.0" />';
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });


### PR DESCRIPTION
Adds support for `zeebe:VersionTag` extension elements at the process level.

### Example

```xml
<bpmn:process 
  id="process-1"
  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
>
  <bpmn:extensionElements>
    <zeebe:versionTag value="v1.0.0" />
  </bpmn:extensionElements>
</bpmn:process>
```

Closes #59