### PR TITLE
feat: support `zeebe:priority`

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -364,6 +364,24 @@
       ]
     },
     {
+      "name": "Priority",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:UserTask"
+        ]
+      },
+      "properties": [
+        {
+          "name": "value",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
+    },
+    {
       "name": "TaskSchedule",
       "superClass": [
         "Element"

--- a/test/fixtures/xml/userTask-zeebe-priority.part.bpmn
+++ b/test/fixtures/xml/userTask-zeebe-priority.part.bpmn
@@ -1,0 +1,9 @@
+<bpmn:userTask
+  id="user-task-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:priority value="75" />
+  </bpmn:extensionElements>
+</bpmn:userTask>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -707,6 +707,37 @@ describe('read', function() {
     });
 
 
+    describe('zeebe:Priority', function() {
+
+      it('on UserTask', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/userTask-zeebe-priority.part.bpmn');
+
+        // when
+        const {
+          rootElement: task
+        } = await moddle.fromXML(xml, 'bpmn:UserTask');
+
+        // then
+        expect(task).to.jsonEqual({
+          $type: 'bpmn:UserTask',
+          id: 'user-task-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:Priority',
+                value: '75'
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
+
     describe('zeebe:TaskSchedule', function() {
 
       it('on UserTask', async function() {

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -372,6 +372,26 @@ describe('write', function() {
     });
 
 
+    it('zeebe:Priority', async function() {
+
+      // given
+      var priority = moddle.create('zeebe:Priority', {
+        value: '100'
+      });
+
+      var expectedXML = '<zeebe:priority ' +
+        'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+        'value="100" />';
+
+      // when
+      const xml = await write(priority);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+
+    });
+
+
     it('zeebe:TaskSchedule', async function() {
 
       // given


### PR DESCRIPTION
Closes #62

~One part which wasn't 100% clear to  me was whether we want to make it an integer or not. I saw that integers are very rare in general in the moddle and plenty of integer-y things are parsed as strings. Also priority is one of those things that could theoretically be either really.~

~So not sure, what do you think~

Nevermind I read through some stuff and I saw we need to support feel, so string it is, undrafting this. 

