### PR TITLE
fix: rename `zeebe:priority` to `zeebe:priorityDefinition`

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -364,7 +364,7 @@
       ]
     },
     {
-      "name": "Priority",
+      "name": "PriorityDefinition",
       "superClass": [
         "Element"
       ],
@@ -375,7 +375,7 @@
       },
       "properties": [
         {
-          "name": "value",
+          "name": "priority",
           "type": "String",
           "isAttr": true
         }

--- a/test/fixtures/xml/userTask-zeebe-priority.part.bpmn
+++ b/test/fixtures/xml/userTask-zeebe-priority.part.bpmn
@@ -4,6 +4,6 @@
   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
 >
   <bpmn:extensionElements>
-    <zeebe:priority value="75" />
+    <zeebe:priorityDefinition priority="75" />
   </bpmn:extensionElements>
 </bpmn:userTask>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -707,7 +707,7 @@ describe('read', function() {
     });
 
 
-    describe('zeebe:Priority', function() {
+    describe('zeebe:PriorityDefinition', function() {
 
       it('on UserTask', async function() {
 
@@ -727,8 +727,8 @@ describe('read', function() {
             $type: 'bpmn:ExtensionElements',
             values: [
               {
-                $type: 'zeebe:Priority',
-                value: '75'
+                $type: 'zeebe:PriorityDefinition',
+                priority: '75'
               }
             ]
           }

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -372,16 +372,16 @@ describe('write', function() {
     });
 
 
-    it('zeebe:Priority', async function() {
+    it('zeebe:PriorityDefinition', async function() {
 
       // given
-      var priority = moddle.create('zeebe:Priority', {
-        value: '100'
+      var priority = moddle.create('zeebe:PriorityDefinition', {
+        priority: '100'
       });
 
-      var expectedXML = '<zeebe:priority ' +
+      var expectedXML = '<zeebe:priorityDefinition ' +
         'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
-        'value="100" />';
+        'priority="100" />';
 
       // when
       const xml = await write(priority);


### PR DESCRIPTION
Closes #62