### PR TITLE
feat: support `versionTag` on `zeebe:BindingTypeSupported`

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -582,6 +582,11 @@
           "isAttr": true,
           "type": "String",
           "default": "latest"
+        },
+        {
+          "name": "versionTag",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     }

--- a/test/fixtures/xml/calledDecision-versionTag.part.bpmn
+++ b/test/fixtures/xml/calledDecision-versionTag.part.bpmn
@@ -1,0 +1,8 @@
+<bpmn:businessRuleTask
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  id="BusinessRuleTask_1">
+  <bpmn:extensionElements>
+    <zeebe:calledDecision bindingType="versionTag" versionTag="v1.0.0" />
+  </bpmn:extensionElements>
+</bpmn:businessRuleTask>

--- a/test/fixtures/xml/calledElement-versionTag.part.bpmn
+++ b/test/fixtures/xml/calledElement-versionTag.part.bpmn
@@ -1,0 +1,8 @@
+<bpmn:callActivity
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  id="CallActivity_1">
+  <bpmn:extensionElements>
+    <zeebe:calledElement bindingType="versionTag" versionTag="v1.0.0" />
+  </bpmn:extensionElements>
+</bpmn:callActivity>

--- a/test/fixtures/xml/formDefinition-versionTag.part.bpmn
+++ b/test/fixtures/xml/formDefinition-versionTag.part.bpmn
@@ -1,0 +1,8 @@
+<bpmn:userTask
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  id="UserTask_1">
+  <bpmn:extensionElements>
+    <zeebe:formDefinition bindingType="versionTag" versionTag="v1.0.0" />
+  </bpmn:extensionElements>
+</bpmn:userTask>

--- a/test/fixtures/xml/zeebe-bindingType.bpmn
+++ b/test/fixtures/xml/zeebe-bindingType.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:userTask id="UserTask_1">
       <bpmn:extensionElements>
@@ -16,6 +16,21 @@
         <zeebe:calledDecision decisionId="foo" resultVariable="bar" bindingType="deployment" />
       </bpmn:extensionElements>
     </bpmn:businessRuleTask>
+    <bpmn:userTask id="UserTask_2">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="foo" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:callActivity id="CallActivity_2">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:businessRuleTask id="BusinessRuleTask_2">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="foo" resultVariable="bar" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -27,6 +42,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BusinessRuleTask_1_di" bpmnElement="BusinessRuleTask_1">
         <dc:Bounds x="480" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xqg1ue_di" bpmnElement="UserTask_2">
+        <dc:Bounds x="160" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f2n3l4_di" bpmnElement="CallActivity_2">
+        <dc:Bounds x="320" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1czqz0h_di" bpmnElement="BusinessRuleTask_2">
+        <dc:Bounds x="480" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1141,6 +1141,94 @@ describe('read', function() {
 
       });
 
+
+      describe('zeebe:versionTag', function() {
+
+        it('on zeebe:CalledDecision', async function() {
+
+          // given
+          var xml = readFile('test/fixtures/xml/calledDecision-versionTag.part.bpmn');
+
+          // when
+          const {
+            rootElement: businessRuleTask
+          } = await moddle.fromXML(xml, 'bpmn:BusinessRuleTask');
+
+          // then
+          expect(businessRuleTask).to.jsonEqual({
+            $type: 'bpmn:BusinessRuleTask',
+            id: 'BusinessRuleTask_1',
+            extensionElements: {
+              $type: 'bpmn:ExtensionElements',
+              values: [
+                {
+                  $type: 'zeebe:CalledDecision',
+                  bindingType: 'versionTag',
+                  versionTag: 'v1.0.0'
+                }
+              ]
+            }
+          });
+        });
+
+
+        it('on zeebe:CalledElement', async function() {
+
+          // given
+          var xml = readFile('test/fixtures/xml/calledElement-versionTag.part.bpmn');
+
+          // when
+          const {
+            rootElement: callActivity
+          } = await moddle.fromXML(xml, 'bpmn:CallActivity');
+
+          // then
+          expect(callActivity).to.jsonEqual({
+            $type: 'bpmn:CallActivity',
+            id: 'CallActivity_1',
+            extensionElements: {
+              $type: 'bpmn:ExtensionElements',
+              values: [
+                {
+                  $type: 'zeebe:CalledElement',
+                  bindingType: 'versionTag',
+                  versionTag: 'v1.0.0'
+                }
+              ]
+            }
+          });
+        });
+
+
+        it('on zeebe:FormDefinition', async function() {
+
+          // given
+          var xml = readFile('test/fixtures/xml/formDefinition-versionTag.part.bpmn');
+
+          // when
+          const {
+            rootElement: userTask
+          } = await moddle.fromXML(xml, 'bpmn:UserTask');
+
+          // then
+          expect(userTask).to.jsonEqual({
+            $type: 'bpmn:UserTask',
+            id: 'UserTask_1',
+            extensionElements: {
+              $type: 'bpmn:ExtensionElements',
+              values: [
+                {
+                  $type: 'zeebe:FormDefinition',
+                  bindingType: 'versionTag',
+                  versionTag: 'v1.0.0'
+                }
+              ]
+            }
+          });
+        });
+
+      });
+
     });
 
   });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -557,60 +557,131 @@ describe('write', function() {
 
     describe('zeebe:BindingTypeSupported', function() {
 
-      it('on zeebe:CalledDecision', async function() {
+      describe('zeebe:bindingType', function() {
 
-        // given
-        const moddleElement = moddle.create('zeebe:CalledDecision', {
-          bindingType: 'deployment'
+        it('on zeebe:CalledDecision', async function() {
+
+          // given
+          const moddleElement = moddle.create('zeebe:CalledDecision', {
+            bindingType: 'deployment'
+          });
+
+          const expectedXML = '<zeebe:calledDecision ' +
+            'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+            'bindingType="deployment" />';
+
+          // when
+          const xml = await write(moddleElement);
+
+          // then
+          expect(xml).to.eql(expectedXML);
         });
 
-        const expectedXML = '<zeebe:calledDecision ' +
-          'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
-          'bindingType="deployment" />';
 
-        // when
-        const xml = await write(moddleElement);
+        it('on zeebe:CalledElement', async function() {
 
-        // then
-        expect(xml).to.eql(expectedXML);
+          // given
+          const moddleElement = moddle.create('zeebe:CalledElement', {
+            bindingType: 'deployment'
+          });
+
+          const expectedXML = '<zeebe:calledElement ' +
+            'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+            'bindingType="deployment" />';
+
+          // when
+          const xml = await write(moddleElement);
+
+          // then
+          expect(xml).to.eql(expectedXML);
+        });
+
+
+        it('on zeebe:FormDefinition', async function() {
+
+          // given
+          const moddleElement = moddle.create('zeebe:FormDefinition', {
+            bindingType: 'deployment'
+          });
+
+          const expectedXML = '<zeebe:formDefinition ' +
+            'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+            'bindingType="deployment" />';
+
+          // when
+          const xml = await write(moddleElement);
+
+          // then
+          expect(xml).to.eql(expectedXML);
+        });
+
       });
 
 
-      it('on zeebe:CalledElement', async function() {
+      describe('zeebe:versionTag', function() {
 
-        // given
-        const moddleElement = moddle.create('zeebe:CalledElement', {
-          bindingType: 'deployment'
+        it('on zeebe:CalledDecision', async function() {
+
+          // given
+          const moddleElement = moddle.create('zeebe:CalledDecision', {
+            bindingType: 'versionTag',
+            versionTag: 'v1.0.0'
+          });
+
+          const expectedXML = '<zeebe:calledDecision ' +
+            'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+            'bindingType="versionTag" ' +
+            'versionTag="v1.0.0" />';
+
+          // when
+          const xml = await write(moddleElement);
+
+          // then
+          expect(xml).to.eql(expectedXML);
         });
 
-        const expectedXML = '<zeebe:calledElement ' +
-          'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
-          'bindingType="deployment" />';
 
-        // when
-        const xml = await write(moddleElement);
+        it('on zeebe:CalledElement', async function() {
 
-        // then
-        expect(xml).to.eql(expectedXML);
-      });
+          // given
+          const moddleElement = moddle.create('zeebe:CalledElement', {
+            bindingType: 'versionTag',
+            versionTag: 'v1.0.0'
+          });
 
+          const expectedXML = '<zeebe:calledElement ' +
+            'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+            'bindingType="versionTag" ' +
+            'versionTag="v1.0.0" />';
 
-      it('on zeebe:FormDefinition', async function() {
+          // when
+          const xml = await write(moddleElement);
 
-        // given
-        const moddleElement = moddle.create('zeebe:FormDefinition', {
-          bindingType: 'deployment'
+          // then
+          expect(xml).to.eql(expectedXML);
         });
 
-        const expectedXML = '<zeebe:formDefinition ' +
-          'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
-          'bindingType="deployment" />';
 
-        // when
-        const xml = await write(moddleElement);
+        it('on zeebe:FormDefinition', async function() {
 
-        // then
-        expect(xml).to.eql(expectedXML);
+          // given
+          const moddleElement = moddle.create('zeebe:FormDefinition', {
+            bindingType: 'versionTag',
+            versionTag: 'v1.0.0'
+          });
+
+          const expectedXML = '<zeebe:formDefinition ' +
+            'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" ' +
+            'bindingType="versionTag" ' +
+            'versionTag="v1.0.0" />';
+
+          // when
+          const xml = await write(moddleElement);
+
+          // then
+          expect(xml).to.eql(expectedXML);
+        });
+
       });
 
     });


### PR DESCRIPTION
* allows setting the `versionTag` property not only on the linked resource (process) but also on the elements that link to that resource (business rule task, call activity, user task)

Related to https://github.com/camunda/camunda-modeler/issues/4460
Related to https://github.com/camunda/camunda-modeler/issues/4461
Related to https://github.com/camunda/camunda-modeler/issues/4462