### PR TITLE
fix: fix `allowedIn` for `zeebe:LoopCharacteristics`

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -187,9 +187,7 @@
       ],
       "meta": {
         "allowedIn": [
-          "zeebe:ZeebeServiceTask",
-          "bpmn:ReceiveTask",
-          "bpmn:SubProcess"
+          "bpmn:MultiInstanceLoopCharacteristics"
         ]
       },
       "properties": [


### PR DESCRIPTION
`zeebe:LoopCharacteristics` isn't restricted to certain flow elements but to `bpmn:MultiInstanceLoopCharacteristics`. This is also how it's [validated by the engine](https://camunda.slack.com/archives/CSQ2E3BT4/p1730123689783969?thread_ts=1730120274.453119&cid=CSQ2E3BT4).

---

Related to https://github.com/camunda/camunda-modeler/issues/4310