### PR TITLE
feat: support zeebe:TaskListener

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -549,6 +549,52 @@
       ]
     },
     {
+      "name": "TaskListeners",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:UserTask"
+        ]
+      },
+      "properties": [
+        {
+          "name": "listeners",
+          "type": "TaskListener",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "TaskListener",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "zeebe:TaskListeners"
+        ]
+      },
+      "properties": [
+        {
+          "name": "eventType",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "retries",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "type",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
+    },
+    {
       "name": "VersionTag",
       "superClass": [
         "Element"

--- a/test/fixtures/xml/userTask-zeebe-taskListener.part.bpmn
+++ b/test/fixtures/xml/userTask-zeebe-taskListener.part.bpmn
@@ -1,0 +1,11 @@
+<bpmn:userTask
+  id="UserTask"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:taskListeners>
+      <zeebe:taskListener eventType="complete" retries="3" type="complete_listener"/>
+    </zeebe:taskListeners>
+  </bpmn:extensionElements>
+</bpmn:userTask>

--- a/test/fixtures/xml/zeebe-taskListeners.bpmn
+++ b/test/fixtures/xml/zeebe-taskListeners.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qh9wc7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:userTaskPlatform="Camunda Cloud" modeler:userTaskPlatformVersion="8.0.0">
+  <bpmn:process id="ZeebePropertiesTest" name="Zeebe Properties Test" isExecutable="true">
+    <bpmn:userTask id="UserTask">
+      <bpmn:extensionElements>
+        <zeebe:taskListeners>
+          <zeebe:taskListener eventType="assign" retries="2" type="assign_listener" />
+        </zeebe:taskListeners>
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:subProcess id="SubProcess">
+      <bpmn:userTask id="UserTaskSubprocess">
+        <bpmn:extensionElements>
+          <zeebe:taskListeners>
+            <zeebe:taskListener eventType="assign" retries="4" type="assign_listener" />
+          </zeebe:taskListeners>
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebePropertiesTest">
+      <bpmndi:BPMNShape id="UserTask_di" bpmnElement="UserTask">
+        <dc:Bounds x="160" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="160" y="510" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTaskSubprocess_di" bpmnElement="UserTaskSubprocess">
+        <dc:Bounds x="200" y="592" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1231,6 +1231,44 @@ describe('read', function() {
 
     });
 
+
+    describe('zeebe:TaskListener', function() {
+
+      it('on UserTask', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/userTask-zeebe-taskListener.part.bpmn');
+
+        // when
+        const {
+          rootElement: task
+        } = await moddle.fromXML(xml, 'bpmn:UserTask');
+
+        // then
+        expect(task).to.jsonEqual({
+          $type: 'bpmn:UserTask',
+          id: 'UserTask',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:TaskListeners',
+                listeners: [
+                  {
+                    $type: 'zeebe:TaskListener',
+                    eventType: 'complete',
+                    retries: '3',
+                    type: 'complete_listener'
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -82,4 +82,11 @@ describe('import -> export roundtrip', function() {
 
   });
 
+
+  describe('zeebe:TaskListeners', function() {
+
+    it('should keep zeebe:taskListeners', validateExport('test/fixtures/xml/zeebe-taskListeners.bpmn'));
+
+  });
+
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -686,6 +686,32 @@ describe('write', function() {
 
     });
 
+
+    it('zeebe:TaskListeners', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:TaskListeners', {
+        listeners: [
+          moddle.create('zeebe:TaskListener', {
+            eventType: 'complete',
+            retries: '1',
+            type: 'complete_listener'
+          })
+        ]
+      });
+
+      const expectedXML = '<zeebe:taskListeners ' +
+        'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">' +
+        '<zeebe:taskListener eventType="complete" retries="1" type="complete_listener" />' +
+        '</zeebe:taskListeners>';
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });


### PR DESCRIPTION
This adds support for `zeebe:TaskListener` contained in `zeebe:TaskListeners` container.

related to https://github.com/camunda/camunda-modeler/issues/4590