### PR TITLE
feat: add support for  zeebe:LinkedResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support `zeebe:LinkedResource` for `bpmn:ServiceTask`
+
 ## 1.7.0
 
 * `FEAT`: support `zeebe:TaskListener` for `bpmn:UserTask` ([#67](https://github.com/camunda/zeebe-bpmn-moddle/pull/67))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -299,6 +299,75 @@
       ]
     },
     {
+      "name": "LinkedResource",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:ServiceTask"
+        ]
+      },
+      "properties": [
+        {
+          "name": "resourceId",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "resourceType",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "linkName",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
+    },
+    {
+      "name": "LinkedResources",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:ServiceTask"
+        ]
+      },
+      "properties": [
+        {
+          "name": "values",
+          "type": "LinkedResource",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "LinkedResource",
+      "superClass": [
+        "Element"
+      ],
+      "properties": [
+        {
+          "name": "resourceId",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "resourceType",
+          "type": "String",
+          "isAttr": true
+        },
+        {
+          "name": "linkName",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
+    },
+    {
       "name": "UserTask",
       "superClass": [
         "Element"
@@ -618,7 +687,8 @@
       "extends": [
         "zeebe:CalledDecision",
         "zeebe:CalledElement",
-        "zeebe:FormDefinition"
+        "zeebe:FormDefinition",
+        "zeebe:LinkedResource"
       ],
       "properties": [
         {

--- a/test/fixtures/xml/zeebe-service-task/serviceTask-zeebe-linkedResource.part.bpmn
+++ b/test/fixtures/xml/zeebe-service-task/serviceTask-zeebe-linkedResource.part.bpmn
@@ -1,0 +1,27 @@
+<bpmn:serviceTask
+  id="collect-money" name="Collect Money"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:linkedResources>
+      <zeebe:linkedResource 
+        resourceId="=myScript"
+        resourceType="RPA"
+        bindingType="latest"
+      ></zeebe:linkedResource>
+      <zeebe:linkedResource 
+        resourceId="=myScript"
+        resourceType="RPA"
+        bindingType="versionTag"
+        versionTag="v1"
+      ></zeebe:linkedResource>
+      <zeebe:linkedResource 
+        resourceId="=myScript"
+        resourceType="RPA"
+        bindingType="deployment"
+        linkName="myScript"
+      ></zeebe:linkedResource>
+    </zeebe:linkedResources>
+  </bpmn:extensionElements>
+</bpmn:serviceTask>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -317,6 +317,59 @@ describe('read', function() {
     });
 
 
+    describe('zeebe:linkedResource', function() {
+
+      it('on ServiceTask', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/zeebe-service-task/serviceTask-zeebe-linkedResource.part.bpmn');
+
+        // when
+        const {
+          rootElement: proc
+        } = await moddle.fromXML(xml, 'bpmn:ServiceTask');
+
+        // then
+        expect(proc).to.jsonEqual({
+          $type: 'bpmn:ServiceTask',
+          id: 'collect-money',
+          name: 'Collect Money',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:LinkedResources',
+                values: [
+                  {
+                    $type: 'zeebe:LinkedResource',
+                    resourceId:'=myScript',
+                    resourceType:'RPA',
+                    bindingType:'latest'
+                  },
+                  {
+                    $type: 'zeebe:LinkedResource',
+                    resourceId: '=myScript',
+                    resourceType: 'RPA',
+                    bindingType: 'versionTag',
+                    versionTag: 'v1'
+                  },
+                  {
+                    $type: 'zeebe:LinkedResource',
+                    resourceId: '=myScript',
+                    resourceType: 'RPA',
+                    bindingType: 'deployment',
+                    linkName: 'myScript'
+                  }
+                ]
+              }
+            ]
+          }
+        });
+
+      });
+
+    });
+
     describe('zeebe:ioMapping / zeebe:Input / zeebe:Output', function() {
 
       it('on ServiceTask', async function() {


### PR DESCRIPTION
This allows modeling of `zeebe:LinkedResource` elements.

Related to https://github.com/bpmn-io/bpmn-js-element-templates/issues/137