### PR TITLE
feat: support `zeebe:AdHoc`

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -680,6 +680,24 @@
           "type": "String"
         }
       ]
+    },
+    {
+      "name": "AdHoc",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:AdHocSubProcess"
+        ]
+      },
+      "properties": [
+        {
+          "name": "activeElementsCollection",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/xml/adhoc-sub-process-zeebe-adHoc.bpmn
+++ b/test/fixtures/xml/adhoc-sub-process-zeebe-adHoc.bpmn
@@ -1,0 +1,8 @@
+<bpmn:adHocSubProcess 
+  id="AdHocSubProcess_1" 
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
+  <bpmn:extensionElements>
+    <zeebe:adHoc activeElementsCollection="=activeElements" />
+  </bpmn:extensionElements>
+</bpmn:adHocSubProcess>

--- a/test/fixtures/xml/zeebe-adHoc.bpmn
+++ b/test/fixtures/xml/zeebe-adHoc.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="ZeebeAdHocTest" name="Zeebe AdHoc Test" isExecutable="true">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=activeElements" />
+      </bpmn:extensionElements>
+      <bpmn:task id="Activity_0dggw2z" />
+      <bpmn:task id="Activity_1e1z8gb" />
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebeAdHocTest">
+      <bpmndi:BPMNShape id="Activity_09e2hj1_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="80" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dggw2z_di" bpmnElement="Activity_0dggw2z">
+        <dc:Bounds x="190" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1e1z8gb_di" bpmnElement="Activity_1e1z8gb">
+        <dc:Bounds x="360" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1322,6 +1322,37 @@ describe('read', function() {
 
     });
 
+
+    describe('zeebe:AdHoc', function() {
+
+      it('on AdHocSubProcess', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/adhoc-sub-process-zeebe-adHoc.bpmn');
+
+        // when
+        const {
+          rootElement: subprocess
+        } = await moddle.fromXML(xml, 'bpmn:AdHocSubProcess');
+
+        // then
+        expect(subprocess).to.jsonEqual({
+          $type: 'bpmn:AdHocSubProcess',
+          id: 'AdHocSubProcess_1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:AdHoc',
+                activeElementsCollection: '=activeElements'
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -96,4 +96,11 @@ describe('import -> export roundtrip', function() {
 
   });
 
+
+  describe('zeebe:AdHoc', function() {
+
+    it('should keep zeebe:adHoc', validateExport('test/fixtures/xml/zeebe-adHoc.bpmn'));
+
+  });
+
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -769,6 +769,21 @@ describe('write', function() {
       // then
       expect(xml).to.eql(expectedXML);
     });
+
+    it('zeebe:AdHoc', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:AdHoc');
+
+      const expectedXML = '<zeebe:adHoc xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" />';
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -773,9 +773,9 @@ describe('write', function() {
     it('zeebe:AdHoc', async function() {
 
       // given
-      const moddleElement = moddle.create('zeebe:AdHoc');
+      const moddleElement = moddle.create('zeebe:AdHoc', { activeElementsCollection: '= some collection' });
 
-      const expectedXML = '<zeebe:adHoc xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" />';
+      const expectedXML = '<zeebe:adHoc xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" activeElementsCollection="= some collection" />';
 
       // when
       const xml = await write(moddleElement);


### PR DESCRIPTION
Add support for `zeebe:AdHoc` in `bpmn:AdHocSubProcess`.

Related to https://github.com/camunda/camunda-modeler/issues/4739