### PR TITLE
feat: support `outputCollection` and `outputElement` on `zeebe:AdHoc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.10.0
+
+* `FEAT`: support `outputCollection` and `outputElement` on `zeebe:AdHoc` ([#72](https://github.com/camunda/zeebe-bpmn-moddle/pull/72))
+
 ## 1.9.0
 
 * `FEAT`: support `zeebe:AdHoc` for `bpmn:AdHocSubprocess` ([#69](https://github.com/camunda/zeebe-bpmn-moddle/pull/69))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -696,6 +696,16 @@
           "name": "activeElementsCollection",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "outputCollection",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "outputElement",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     }

--- a/test/fixtures/xml/adhoc-sub-process-zeebe-adHoc.bpmn
+++ b/test/fixtures/xml/adhoc-sub-process-zeebe-adHoc.bpmn
@@ -3,6 +3,6 @@
   xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
   <bpmn:extensionElements>
-    <zeebe:adHoc activeElementsCollection="=activeElements" />
+    <zeebe:adHoc activeElementsCollection="=activeElements" outputCollection="results" outputElement="= result" />
   </bpmn:extensionElements>
 </bpmn:adHocSubProcess>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1344,7 +1344,9 @@ describe('read', function() {
             values: [
               {
                 $type: 'zeebe:AdHoc',
-                activeElementsCollection: '=activeElements'
+                activeElementsCollection: '=activeElements',
+                outputCollection: 'results',
+                outputElement: '= result'
               }
             ]
           }

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -773,9 +773,13 @@ describe('write', function() {
     it('zeebe:AdHoc', async function() {
 
       // given
-      const moddleElement = moddle.create('zeebe:AdHoc', { activeElementsCollection: '= some collection' });
+      const moddleElement = moddle.create('zeebe:AdHoc', {
+        activeElementsCollection: '= some collection',
+        outputCollection: 'results',
+        outputElement: '= result'
+      });
 
-      const expectedXML = '<zeebe:adHoc xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" activeElementsCollection="= some collection" />';
+      const expectedXML = '<zeebe:adHoc xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" activeElementsCollection="= some collection" outputCollection="results" outputElement="= result" />';
 
       // when
       const xml = await write(moddleElement);


### PR DESCRIPTION
Related to https://github.com/camunda/tmp-camunda-modeler-adhoc-subprocess/issues/3