### PR TITLE
feat: support `zeebe:ConditionalFilter` properties on `bpmn:ConditionalEventDefinition`

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -709,6 +709,29 @@
           "type": "String"
         }
       ]
+    },
+    {
+      "name": "ConditionalFilter",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:ConditionalEventDefinition"
+        ]
+      },
+      "properties": [
+        {
+          "name": "variableNames",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "variableEvents",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/xml/startEvent-zeebe-conditionalFilter.part.bpmn
+++ b/test/fixtures/xml/startEvent-zeebe-conditionalFilter.part.bpmn
@@ -1,0 +1,7 @@
+<bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="start">
+  <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1">
+    <bpmn:extensionElements>
+      <zeebe:conditionalFilter variableNames="foo,bar" variableEvents="create,update"  />
+    </bpmn:extensionElements>
+  </bpmn:conditionalEventDefinition>
+</bpmn:startEvent>

--- a/test/fixtures/xml/zeebe-conditionalFilter.bpmn
+++ b/test/fixtures/xml/zeebe-conditionalFilter.bpmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.42.0">
+  <bpmn:process id="ConditionalEvent" name="ConditionalEvent" isExecutable="true">
+    <bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="start">
+  <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1">
+    <bpmn:extensionElements>
+      <zeebe:conditionalFilter variableNames="foo,bar" variableEvents="create,update" />
+    </bpmn:extensionElements>
+  </bpmn:conditionalEventDefinition>
+</bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ConditionalEvent">
+      <bpmndi:BPMNShape id="Event_1tij2fe_di" bpmnElement="start">
+        <dc:Bounds x="132" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1762,6 +1762,44 @@ describe('read', function() {
 
     });
 
+
+    describe('zeebe:conditionalFilter', function() {
+
+      it('on ConditionalEventDefinition in StartEvent', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/startEvent-zeebe-conditionalFilter.part.bpmn');
+
+        // when
+        const {
+          rootElement: event
+        } = await moddle.fromXML(xml, 'bpmn:StartEvent');
+
+        // then
+        expect(event).to.jsonEqual({
+          $type: 'bpmn:StartEvent',
+          id: 'start',
+          eventDefinitions: [
+            {
+              $type: 'bpmn:ConditionalEventDefinition',
+              id: 'ConditionalEventDefinition_1',
+              extensionElements: {
+                $type: 'bpmn:ExtensionElements',
+                values: [
+                  {
+                    $type: 'zeebe:ConditionalFilter',
+                    variableNames: 'foo,bar',
+                    variableEvents: 'create,update'
+                  }
+                ]
+              }
+            }
+          ]
+        });
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -103,4 +103,11 @@ describe('import -> export roundtrip', function() {
 
   });
 
+
+  describe('zeebe:ConditionalFilter', function() {
+
+    it('should keep zeebe:conditionalFilter', validateExport('test/fixtures/xml/zeebe-conditionalFilter.bpmn'));
+
+  });
+
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -770,6 +770,7 @@ describe('write', function() {
       expect(xml).to.eql(expectedXML);
     });
 
+
     it('zeebe:AdHoc', async function() {
 
       // given
@@ -780,6 +781,24 @@ describe('write', function() {
       });
 
       const expectedXML = '<zeebe:adHoc xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" activeElementsCollection="= some collection" outputCollection="results" outputElement="= result" />';
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
+
+    it('zeebe:ConditionalFilter', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:ConditionalFilter', {
+        variableNames: 'foo,bar',
+        variableEvents: 'create,update'
+      });
+
+      const expectedXML = '<zeebe:conditionalFilter xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" variableNames="foo,bar" variableEvents="create,update" />';
 
       // when
       const xml = await write(moddleElement);


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5400

Add support for Zeebe properties for modeling conditional events.