### PR TITLE
fix: allow `FormDefinition` on Start event

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -279,7 +279,8 @@
       ],
       "meta": {
         "allowedIn": [
-          "bpmn:UserTask"
+          "bpmn:UserTask",
+          "bpmn:StartEvent"
         ]
       },
       "properties": [

--- a/test/fixtures/xml/startEvent-zeebe-formDefinition-formId.part.bpmn
+++ b/test/fixtures/xml/startEvent-zeebe-formDefinition-formId.part.bpmn
@@ -1,0 +1,9 @@
+<bpmn:startEvent 
+  id="start-event-1" 
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:formDefinition formId="form-1" />
+  </bpmn:extensionElements>
+</bpmn:startEvent>

--- a/test/fixtures/xml/startEvent-zeebe-formDefinition-formKey.part.bpmn
+++ b/test/fixtures/xml/startEvent-zeebe-formDefinition-formKey.part.bpmn
@@ -1,0 +1,9 @@
+<bpmn:startEvent 
+  id="start-event-1" 
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:formDefinition formKey="camunda-forms:bpmn:form-1" />
+  </bpmn:extensionElements>
+</bpmn:startEvent>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1070,6 +1070,64 @@ describe('read', function() {
         });
       });
 
+
+      describe('on StartEvent', function() {
+
+        it('zeebe:formId', async function() {
+
+          // given
+          var xml = readFile('test/fixtures/xml/startEvent-zeebe-formDefinition-formId.part.bpmn');
+
+          // when
+          const {
+            rootElement: event
+          } = await moddle.fromXML(xml, 'bpmn:StartEvent');
+
+          // then
+          expect(event).to.jsonEqual({
+            $type: 'bpmn:StartEvent',
+            id: 'start-event-1',
+            extensionElements: {
+              $type: 'bpmn:ExtensionElements',
+              values: [
+                {
+                  $type: 'zeebe:FormDefinition',
+                  formId: 'form-1'
+                }
+              ]
+            }
+          });
+        });
+
+
+        it('zeebe:formKey', async function() {
+
+          // given
+          var xml = readFile('test/fixtures/xml/startEvent-zeebe-formDefinition-formKey.part.bpmn');
+
+          // when
+          const {
+            rootElement: event
+          } = await moddle.fromXML(xml, 'bpmn:StartEvent');
+
+          // then
+          expect(event).to.jsonEqual({
+            $type: 'bpmn:StartEvent',
+            id: 'start-event-1',
+            extensionElements: {
+              $type: 'bpmn:ExtensionElements',
+              values: [
+                {
+                  $type: 'zeebe:FormDefinition',
+                  formKey: 'camunda-forms:bpmn:form-1'
+                }
+              ]
+            }
+          });
+        });
+
+      });
+
     });
 
 

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -320,6 +320,65 @@ describe('write', function() {
         // then
         expect(xml).to.eql(expectedXML);
       });
+
+
+      it('zeebe:formId on StartEvent', async function() {
+
+        // given
+        var event = moddle.create('bpmn:StartEvent', {
+          extensionElements: moddle.create('bpmn:ExtensionElements', {
+            values: [
+              moddle.create('zeebe:FormDefinition', {
+                formId: 'form-1'
+              })
+            ]
+          })
+        });
+
+        const expectedXML = normalizeXMLWhitespace(`
+          <bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
+            <bpmn:extensionElements>
+              <zeebe:formDefinition formId="form-1" />
+            </bpmn:extensionElements>
+          </bpmn:startEvent>
+        `);
+
+        // when
+        const xml = await write(event);
+
+        // then
+        expect(xml).to.eql(expectedXML);
+      });
+
+
+      it('zeebe:formKey on StartEvent', async function() {
+
+        // given
+        var event = moddle.create('bpmn:StartEvent', {
+          extensionElements: moddle.create('bpmn:ExtensionElements', {
+            values: [
+              moddle.create('zeebe:FormDefinition', {
+                formKey: 'camunda-forms:bpmn:form-1'
+              })
+            ]
+          })
+        });
+
+        const expectedXML = normalizeXMLWhitespace(`
+          <bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
+            <bpmn:extensionElements>
+              <zeebe:formDefinition formKey="camunda-forms:bpmn:form-1" />
+            </bpmn:extensionElements>
+          </bpmn:startEvent>
+        `);
+
+        // when
+        const xml = await write(event);
+
+        // then
+        expect(xml).to.eql(expectedXML);
+      });
+
     });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4672

Allow `FormDefinition` on Start event