### PR TITLE
feat: add zeebe:jobPriorityDefinition moddle type

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -738,6 +738,28 @@
           "type": "String"
         }
       ]
+    },
+    {
+      "name": "JobPriorityDefinition",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:Process",
+          "bpmn:ServiceTask",
+          "bpmn:SendTask",
+          "bpmn:BusinessRuleTask",
+          "bpmn:ScriptTask"
+        ]
+      },
+      "properties": [
+        {
+          "name": "priority",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/xml/process-zeebe-jobPriority.part.bpmn
+++ b/test/fixtures/xml/process-zeebe-jobPriority.part.bpmn
@@ -1,0 +1,9 @@
+<bpmn:process
+  id="process-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:jobPriorityDefinition priority="50" />
+  </bpmn:extensionElements>
+</bpmn:process>

--- a/test/fixtures/xml/serviceTask-zeebe-jobPriority.part.bpmn
+++ b/test/fixtures/xml/serviceTask-zeebe-jobPriority.part.bpmn
@@ -1,0 +1,10 @@
+<bpmn:serviceTask
+  id="service-task-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:taskDefinition type="worker" />
+    <zeebe:jobPriorityDefinition priority="90" />
+  </bpmn:extensionElements>
+</bpmn:serviceTask>

--- a/test/fixtures/xml/zeebe-jobPriority.bpmn
+++ b/test/fixtures/xml/zeebe-jobPriority.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:jobPriorityDefinition priority="50" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="worker" />
+        <zeebe:jobPriorityDefinition priority="90" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1256,6 +1256,68 @@ describe('read', function() {
     });
 
 
+    describe('zeebe:JobPriorityDefinition', function() {
+
+      it('on Process', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/process-zeebe-jobPriority.part.bpmn');
+
+        // when
+        const {
+          rootElement: process
+        } = await moddle.fromXML(xml, 'bpmn:Process');
+
+        // then
+        expect(process).to.jsonEqual({
+          $type: 'bpmn:Process',
+          id: 'process-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:JobPriorityDefinition',
+                priority: '50'
+              }
+            ]
+          }
+        });
+      });
+
+
+      it('on ServiceTask', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/serviceTask-zeebe-jobPriority.part.bpmn');
+
+        // when
+        const {
+          rootElement: task
+        } = await moddle.fromXML(xml, 'bpmn:ServiceTask');
+
+        // then
+        expect(task).to.jsonEqual({
+          $type: 'bpmn:ServiceTask',
+          id: 'service-task-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:TaskDefinition',
+                type: 'worker'
+              },
+              {
+                $type: 'zeebe:JobPriorityDefinition',
+                priority: '90'
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
+
     describe('zeebe:TaskSchedule', function() {
 
       it('on UserTask', async function() {

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -110,4 +110,11 @@ describe('import -> export roundtrip', function() {
 
   });
 
+
+  describe('zeebe:JobPriorityDefinition', function() {
+
+    it('should keep zeebe:jobPriorityDefinition', validateExport('test/fixtures/xml/zeebe-jobPriority.bpmn'));
+
+  });
+
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -463,6 +463,24 @@ describe('write', function() {
     });
 
 
+    it('zeebe:JobPriorityDefinition', async function() {
+
+      // given
+      var jobPriority = moddle.create('zeebe:JobPriorityDefinition', {
+        priority: '90'
+      });
+
+      const expectedXML = '<zeebe:jobPriorityDefinition xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" priority="90" />';
+
+      // when
+      const xml = await write(jobPriority);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+
+    });
+
+
     it('zeebe:TaskSchedule', async function() {
 
       // given


### PR DESCRIPTION
Adds the `zeebe:JobPriorityDefinition` moddle type — a single `priority` attribute (`String`, FEEL-capable) allowed in `bpmn:Process`, `bpmn:ServiceTask`, `bpmn:SendTask`, `bpmn:BusinessRuleTask` and `bpmn:ScriptTask`.

Part of the Camunda 8 job-prioritization effort tracked in camunda/camunda-modeler#5889. This is the root of the dependency chain; downstream repos (properties-panel, bpmnlint-plugin-camunda-compat, element-templates) consume this type.

- New type in `resources/zeebe.json`
- read / write / roundtrip specs + fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)