### PR TITLE
feat: add configuration template support

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -525,6 +525,26 @@
       ]
     },
     {
+      "name": "ConfigurationSupported",
+      "isAbstract": true,
+      "extends": [
+        "zeebe:Input",
+        "zeebe:Property"
+      ],
+      "properties": [
+        {
+          "name": "modelerConfigurationTemplate",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "modelerConfigurationName",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "TemplatedRootElement",
       "isAbstract": true,
       "extends": [

--- a/test/fixtures/xml/input-zeebe-modelerConfiguration.part.bpmn
+++ b/test/fixtures/xml/input-zeebe-modelerConfiguration.part.bpmn
@@ -1,0 +1,3 @@
+<zeebe:input xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+             zeebe:modelerConfigurationTemplate="io.camunda:slack-connection:1"
+             zeebe:modelerConfigurationName="Slack Production" />

--- a/test/fixtures/xml/property-zeebe-modelerConfiguration.part.bpmn
+++ b/test/fixtures/xml/property-zeebe-modelerConfiguration.part.bpmn
@@ -1,0 +1,3 @@
+<zeebe:property xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                zeebe:modelerConfigurationTemplate="io.camunda:slack-connection:1"
+                zeebe:modelerConfigurationName="Slack Production" />

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -1462,6 +1462,48 @@ describe('read', function() {
     });
 
 
+    describe('zeebe:ConfigurationSupported', function() {
+
+      it('on Input', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/input-zeebe-modelerConfiguration.part.bpmn');
+
+        // when
+        const {
+          rootElement: input
+        } = await moddle.fromXML(xml, 'zeebe:Input');
+
+        // then
+        expect(input).to.jsonEqual({
+          $type: 'zeebe:Input',
+          modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+          modelerConfigurationName: 'Slack Production'
+        });
+      });
+
+
+      it('on Property', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/property-zeebe-modelerConfiguration.part.bpmn');
+
+        // when
+        const {
+          rootElement: property
+        } = await moddle.fromXML(xml, 'zeebe:Property');
+
+        // then
+        expect(property).to.jsonEqual({
+          $type: 'zeebe:Property',
+          modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+          modelerConfigurationName: 'Slack Production'
+        });
+      });
+
+    });
+
+
     describe('zeebe:script', function() {
 
       it('on ScriptTask', async function() {

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -592,6 +592,46 @@ describe('write', function() {
     });
 
 
+    it('zeebe:modelerConfigurationTemplate on Input', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:Input', {
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Production'
+      });
+
+      const expectedXML = normalizeXMLWhitespace(`
+        <zeebe:input xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" modelerConfigurationTemplate="io.camunda:slack-connection:1" modelerConfigurationName="Slack Production" />
+      `);
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
+
+    it('zeebe:modelerConfigurationTemplate on Property', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:Property', {
+        modelerConfigurationTemplate: 'io.camunda:slack-connection:1',
+        modelerConfigurationName: 'Slack Production'
+      });
+
+      const expectedXML = normalizeXMLWhitespace(`
+        <zeebe:property xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" modelerConfigurationTemplate="io.camunda:slack-connection:1" modelerConfigurationName="Slack Production" />
+      `);
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
+
     it('zeebe:script', async function() {
 
       // given


### PR DESCRIPTION
Adds abstract type `ConfigurationSupported` extending `zeebe:Input` and `zeebe:Property` with two design-time attributes:

- `modelerConfigurationTemplate` — configuration template ID used for validation and chooser filtering
- `modelerConfigurationName` — cached display name for offline UX

```xml
<zeebe:input
  source="..."
  target="..."
  zeebe:modelerConfigurationTemplate="io.camunda:slack-connection:1"
  zeebe:modelerConfigurationName="Slack Production" />
```

Follows the same pattern as [`TemplateSupported`](https://github.com/camunda/zeebe-bpmn-moddle/blob/27f7859482db18830cc3e4256fca297eceb56c3e/resources/zeebe.json#L502).

---

Closes https://github.com/camunda/zeebe-bpmn-moddle/issues/89
Related to https://github.com/bpmn-io/internal-docs/issues/1340