### PR TITLE
feat: add businessId to zeebe:CalledElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.17.0
+
+* `FEAT`: add `businessId` to `zeebe:CalledElement` for Call Activity Business ID propagation ([#90](https://github.com/camunda/zeebe-bpmn-moddle/pull/90))
+
 ## 1.16.0
 
 * `FEAT`: add configuration templates / `zeebe:ConfigurationSupported` ([#89](https://github.com/camunda/zeebe-bpmn-moddle/issues/89), [#88](https://github.com/camunda/zeebe-bpmn-moddle/pull/88))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -246,6 +246,11 @@
           "isAttr": true,
           "type": "Boolean",
           "default": true
+        },
+        {
+          "name": "businessId",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },

--- a/test/fixtures/xml/calledElement-businessId.part.bpmn
+++ b/test/fixtures/xml/calledElement-businessId.part.bpmn
@@ -1,0 +1,8 @@
+<bpmn:callActivity
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  id="CallActivity_1">
+  <bpmn:extensionElements>
+    <zeebe:calledElement businessId="=order.customerId" />
+  </bpmn:extensionElements>
+</bpmn:callActivity>

--- a/test/fixtures/xml/zeebe-businessId.bpmn
+++ b/test/fixtures/xml/zeebe-businessId.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:callActivity id="CallActivity_expression">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" businessId="=order.customerId" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_literal">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" businessId="order-123" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_empty">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" businessId="" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="CallActivity_expression_di" bpmnElement="CallActivity_expression">
+        <dc:Bounds x="160" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_literal_di" bpmnElement="CallActivity_literal">
+        <dc:Bounds x="160" y="197" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_empty_di" bpmnElement="CallActivity_empty">
+        <dc:Bounds x="160" y="317" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -503,6 +503,33 @@ describe('read', function() {
         });
       });
 
+
+      it('with businessId', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/calledElement-businessId.part.bpmn');
+
+        // when
+        const {
+          rootElement: callActivity
+        } = await moddle.fromXML(xml, 'bpmn:CallActivity');
+
+        // then
+        expect(callActivity).to.jsonEqual({
+          $type: 'bpmn:CallActivity',
+          id: 'CallActivity_1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:CalledElement',
+                businessId: '=order.customerId'
+              }
+            ]
+          }
+        });
+      });
+
     });
 
 

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -83,6 +83,13 @@ describe('import -> export roundtrip', function() {
   });
 
 
+  describe('zeebe:CalledElement businessId', function() {
+
+    it('should keep businessId (expression, literal and empty)', validateExport('test/fixtures/xml/zeebe-businessId.bpmn'));
+
+  });
+
+
   describe('zeebe:TaskListeners', function() {
 
     it('should keep zeebe:taskListeners', validateExport('test/fixtures/xml/zeebe-taskListeners.bpmn'));

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -198,6 +198,40 @@ describe('write', function() {
     });
 
 
+    it('CalledElement#businessId - value', async function() {
+
+      // given
+      var fieldElem = moddle.create('zeebe:CalledElement', {
+        businessId: '=order.customerId'
+      });
+
+      const expectedXML = '<zeebe:calledElement xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" businessId="=order.customerId" />';
+
+      // when
+      const xml = await write(fieldElem);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
+
+    it('CalledElement#businessId - empty (null override)', async function() {
+
+      // given
+      var fieldElem = moddle.create('zeebe:CalledElement', {
+        businessId: ''
+      });
+
+      const expectedXML = '<zeebe:calledElement xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" businessId="" />';
+
+      // when
+      const xml = await write(fieldElem);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
+
     it('zeebe:userTaskForm', async function() {
 
       // given


### PR DESCRIPTION
Below is the 🤖 message. I leave it as it's accurate

---

Adds a `businessId` attribute to `zeebe:CalledElement` so modelers can configure how a Call Activity sets the Business ID of its child process instance. Absent = inherit from parent, present (incl. empty) = override with a literal value or FEEL expression.

Related to https://github.com/camunda/camunda-modeler/issues/5912