### PR TITLE
feat: add zeebe:agentDefinition extension element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [zeebe-bpmn-moddle](https://github.com/camunda/zeebe-bpmn
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add `zeebe:agentDefinition` extension element ([#94](https://github.com/camunda/zeebe-bpmn-moddle/pull/94))
+
 ## 1.17.0
 
 * `FEAT`: add `businessId` to `zeebe:CalledElement` for Call Activity Business ID propagation ([#90](https://github.com/camunda/zeebe-bpmn-moddle/pull/90))

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -782,6 +782,25 @@
           "type": "String"
         }
       ]
+    },
+    {
+      "name": "AgentDefinition",
+      "superClass": [
+        "Element"
+      ],
+      "meta": {
+        "allowedIn": [
+          "bpmn:ServiceTask",
+          "bpmn:AdHocSubProcess"
+        ]
+      },
+      "properties": [
+        {
+          "name": "agentType",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/xml/adhoc-sub-process-zeebe-agentDefinition.part.bpmn
+++ b/test/fixtures/xml/adhoc-sub-process-zeebe-agentDefinition.part.bpmn
@@ -1,0 +1,8 @@
+<bpmn:adHocSubProcess
+  id="AdHocSubProcess_1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">
+  <bpmn:extensionElements>
+    <zeebe:agentDefinition agentType="aiAgentSubProcess" />
+  </bpmn:extensionElements>
+</bpmn:adHocSubProcess>

--- a/test/fixtures/xml/serviceTask-zeebe-agentDefinition.part.bpmn
+++ b/test/fixtures/xml/serviceTask-zeebe-agentDefinition.part.bpmn
@@ -1,0 +1,9 @@
+<bpmn:serviceTask
+  id="service-task-1"
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+>
+  <bpmn:extensionElements>
+    <zeebe:agentDefinition agentType="aiAgentTask" />
+  </bpmn:extensionElements>
+</bpmn:serviceTask>

--- a/test/fixtures/xml/zeebe-agentDefinition.bpmn
+++ b/test/fixtures/xml/zeebe-agentDefinition.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="ZeebeAgentDefinitionTest" name="Zeebe AgentDefinition Test" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1">
+      <bpmn:extensionElements>
+        <zeebe:agentDefinition agentType="aiAgentTask" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ZeebeAgentDefinitionTest">
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -2000,6 +2000,64 @@ describe('read', function() {
 
     });
 
+
+    describe('zeebe:agentDefinition', function() {
+
+      it('on ServiceTask', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/serviceTask-zeebe-agentDefinition.part.bpmn');
+
+        // when
+        const {
+          rootElement: task
+        } = await moddle.fromXML(xml, 'bpmn:ServiceTask');
+
+        // then
+        expect(task).to.jsonEqual({
+          $type: 'bpmn:ServiceTask',
+          id: 'service-task-1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:AgentDefinition',
+                agentType: 'aiAgentTask'
+              }
+            ]
+          }
+        });
+      });
+
+
+      it('on AdHocSubProcess', async function() {
+
+        // given
+        var xml = readFile('test/fixtures/xml/adhoc-sub-process-zeebe-agentDefinition.part.bpmn');
+
+        // when
+        const {
+          rootElement: subprocess
+        } = await moddle.fromXML(xml, 'bpmn:AdHocSubProcess');
+
+        // then
+        expect(subprocess).to.jsonEqual({
+          $type: 'bpmn:AdHocSubProcess',
+          id: 'AdHocSubProcess_1',
+          extensionElements: {
+            $type: 'bpmn:ExtensionElements',
+            values: [
+              {
+                $type: 'zeebe:AgentDefinition',
+                agentType: 'aiAgentSubProcess'
+              }
+            ]
+          }
+        });
+      });
+
+    });
+
   });
 
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -117,4 +117,11 @@ describe('import -> export roundtrip', function() {
 
   });
 
+
+  describe('zeebe:AgentDefinition', function() {
+
+    it('should keep zeebe:agentDefinition', validateExport('test/fixtures/xml/zeebe-agentDefinition.bpmn'));
+
+  });
+
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -1018,6 +1018,27 @@ describe('write', function() {
       expect(xml).to.eql(expectedXML);
     });
 
+
+    it('zeebe:AgentDefinition', async function() {
+
+      // given
+      const moddleElement = moddle.create('zeebe:AgentDefinition', {
+        agentType: 'aiAgentTask'
+      });
+
+      const expectedXML = normalizeXMLWhitespace(`
+        <zeebe:agentDefinition 
+        xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" 
+        agentType="aiAgentTask" />
+      `);
+
+      // when
+      const xml = await write(moddleElement);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });


### PR DESCRIPTION
Adds a new `zeebe:AgentDefinition` moddle type for the `<zeebe:agentDefinition agentType="..."/>` extension element, nestable inside `bpmn:ExtensionElements` on a `bpmn:ServiceTask` or `bpmn:AdHocSubProcess`.

Mirrors the existing single-instance extension element pattern used by `zeebe:CalledDecision`/`zeebe:FormDefinition`/`zeebe:AdHoc` (plain `Element` type, `meta.allowedIn` for documentation purposes, `agentType` as an unrestricted `String` attribute — actual value/element-type restriction is enforced downstream in [camunda/element-templates-json-schema](https://github.com/camunda/element-templates-json-schema/pull/265)).

Part of the work to support `zeebe:agentDefinition` end to end — see camunda/element-templates-json-schema#265 (element-template binding + JSON schema validation) and bpmn-io/bpmn-js-element-templates (properties-panel application logic) for the companion changes.

Related to https://github.com/camunda/camunda-modeler/issues/6094